### PR TITLE
Missing space before "Save Changes".

### DIFF
--- a/src/saveButton/save-button-tpl.html
+++ b/src/saveButton/save-button-tpl.html
@@ -14,9 +14,9 @@
         </div>
 
         <!--ALL CHANGES UP TO DATE-->
-        <span ng-if="!saveButton.savingChangesTrigger && !saveButton.unsavedChangesTrigger"><i class="lumen-icon__graphic lumen-icon__graphic--check-open"></i> Changes are up to date</span>
+        <span ng-if="!saveButton.savingChangesTrigger && !saveButton.unsavedChangesTrigger"><i class="lumen-icon__graphic lumen-icon__graphic--check-open"></i> {{ saveButton.noUnsavedChangesText || "Changes are up to date" }}</span>
 
         <!--UNSAVED CHANGES-->
-        <span ng-if="saveButton.unsavedChangesTrigger && !saveButton.savingChangesTrigger"><i class="lumen-icon__graphic lumen-icon__graphic--warning"></i>Save Changes</span>
+        <span ng-if="saveButton.unsavedChangesTrigger && !saveButton.savingChangesTrigger"><i class="lumen-icon__graphic lumen-icon__graphic--warning"></i> {{ saveButton.saveChangesText || "Save Changes" }}</span>
     </button>
 </span>


### PR DESCRIPTION
There is a missing space before the "Save Changes" text. This causes the icon to be squished with the text which causes it to look unpolished. Ideally, the "Save Changes" text and the "Changes are up to date" text should be settable from attributes on the <save-button> element.